### PR TITLE
Update lib.php

### DIFF
--- a/cli/lib.php
+++ b/cli/lib.php
@@ -141,7 +141,7 @@ function safety_checks($options) {
 
     // 4. Check for an explicit flag in config.php just to be extra mega cautious!
     if (empty($CFG->config_php_settings['local_datacleaner_allowexecution'])) {
-        abort_message(get_string('error:explicitconfigphp', 'local_datacleaner'));
+        abort_message(get_string('error:explicitconfigphp', 'local_datacleaner'),'');
         $willdie = true;
     }
 


### PR DESCRIPTION
To fix the warning message:
PHP Warning:  Missing argument 2 for abort_message(), called in .../yourmoodle/local/datacleaner/cli/lib.php on line 144 and defined in .../yourmoodle/local/datacleaner/cli/lib.php on line 50